### PR TITLE
Enhance mvn test execution to prevent process being stuck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.11</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.10</version>
+    <version>1.11-SNAPSHOT</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -160,6 +160,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         if (exited) {
             return proc.exitValue();
         } else {
+            proc.destroyForcibly();
             return 1;
         }
     }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -101,6 +101,12 @@ public class SuperTestMavenPlugin extends AbstractMojo {
             }
 
             final String runCommand = createRerunCommand(classnameToTestcaseList);
+
+            // previous run exited with code > 0, but all tests were actually run successfully
+            if (runCommand == null) {
+                return;
+            }
+
             final StringBuilder rerunCommand = new StringBuilder(runCommand);
             rerunCommand.append(buildProcessedMvnTestOpts(artifactId, groupId));
             if (rerunProfile != null) {
@@ -245,6 +251,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
      * @return rerunCommand
      */
     public String createRerunCommand(Map<String, List<String>> classnameToTestcaseList) {
+        boolean hasTestsAppended = false;
         final StringBuilder retryRun = new StringBuilder("mvn test");
         retryRun.append(" -Dtest=");
         // TODO: 04/02/2022 replace with Java 8 streams
@@ -252,6 +259,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
             if (!failedTestCaseList.isEmpty()) {
                 retryRun.append(className);
+                hasTestsAppended = true;
                 if(failedTestCaseList.contains("")) {
                     retryRun.append(",");
                     continue;
@@ -267,6 +275,6 @@ public class SuperTestMavenPlugin extends AbstractMojo {
                 }
             }
         }
-        return retryRun.toString();
+        return hasTestsAppended ? retryRun.toString() : null;
     }
 }


### PR DESCRIPTION
* Stderr is now read to prevent hanging in case of an error (also err…ors are visible in the logs)
* Timeout is introduced in case no activity is detected on stdout/stderr when a new process is started