### PR TITLE
Do not skip tests on rerun if maven run exited prematurely or was forcibly killed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.12-SNAPSHOT</version>
+    <version>1.12</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.11</version>
+    <version>1.12-SNAPSHOT</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>
@@ -42,6 +42,11 @@
             <artifactId>maven-project</artifactId>
             <version>2.2.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/clevertap/maven/plugins/supertest/RunResult.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/RunResult.java
@@ -5,20 +5,19 @@ import java.util.List;
 
 public class RunResult {
 
-    final String className;
-    final List<String> testCases;
+    private final String className;
+    private final List<String> failedTestCases = new ArrayList<>();
 
     public RunResult(String className) {
         this.className = className;
-        this.testCases = new ArrayList<>();
     }
 
-    public void addTestCase(final String testCase) {
-        testCases.add(testCase);
+    public void addFailedTestCase(final String testCase) {
+        failedTestCases.add(testCase);
     }
 
-    public List<String> getTestCases() {
-        return testCases;
+    public List<String> getFailedTestCases() {
+        return failedTestCases;
     }
 
     public String getClassName() {

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -277,7 +277,6 @@ public class SuperTestMavenPlugin extends AbstractMojo {
      */
     public String createRerunCommand(
             Set<String> allTestClasses, Map<String, List<String>> classnameToTestcaseList) {
-        boolean hasTestsAppended = false;
         final StringBuilder retryRun = new StringBuilder("mvn test");
         Set<String> incompleteTests = new HashSet<>(allTestClasses);
 
@@ -291,21 +290,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
 
             if (!failedTestCaseList.isEmpty()) {
-                retryRun.append(className);
-                hasTestsAppended = true;
-                if(failedTestCaseList.contains("")) {
-                    retryRun.append(",");
-                    continue;
-                }
-                retryRun.append("#");
-                for (int i = 0; i < failedTestCaseList.size(); i++) {
-                    retryRun.append(failedTestCaseList.get(i)).append("*");
-                    if (i == failedTestCaseList.size() - 1) {
-                        retryRun.append(",");
-                    } else {
-                        retryRun.append("+");
-                    }
-                }
+                appendFailedTestCases(className, failedTestCaseList, retryRun);
             } else {
                 // passing tests will not be re-run anymore
                 allTestClasses.remove(className);
@@ -320,6 +305,28 @@ public class SuperTestMavenPlugin extends AbstractMojo {
 
         retryRun.append(String.join(",", incompleteTests));
 
-        return hasTestsAppended ? retryRun.toString() : null;
+        return retryRun.length() != emptyRetryRunLen ? retryRun.toString() : null;
+    }
+
+    private void appendFailedTestCases(
+            String className, List<String> failedTestCaseList, StringBuilder retryRun) {
+        retryRun.append(className);
+
+        if (failedTestCaseList.contains("")) {
+            retryRun.append(",");
+            return;
+        }
+
+        retryRun.append("#");
+
+        for (int i = 0; i < failedTestCaseList.size(); i++) {
+            retryRun.append(failedTestCaseList.get(i)).append("*");
+
+            if (i == failedTestCaseList.size() - 1) {
+                retryRun.append(",");
+            } else {
+                retryRun.append("+");
+            }
+        }
     }
 }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -82,7 +82,14 @@ public class SuperTestMavenPlugin extends AbstractMojo {
 
         pool = Executors.newFixedThreadPool(1);
         Set<String> allTestClasses = new HashSet<>(new TestListResolver(
-                includes, excludes, getTest(), "target/surefire-reports").scanDirectories());
+                includes,
+                excludes,
+                getTest(),
+                new File(baseDir, "target/test-classes").getAbsolutePath()).scanDirectories());
+
+        getLog().debug("Test classes dir: "
+                + new File(baseDir, "target/test-classes").getAbsolutePath());
+        getLog().debug("Test classes found: " + String.join(",", allTestClasses));
 
         int exitCode;
         final String command = "mvn test " + buildProcessedMvnTestOpts(artifactId, groupId);

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -81,14 +81,14 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         final String groupId = project.getGroupId();
 
         pool = Executors.newFixedThreadPool(1);
-        Set<String> allTestClasses = new HashSet<>(new TestListResolver(
-                includes,
-                excludes,
-                getTest(),
-                new File(baseDir, "target/test-classes").getAbsolutePath()).scanDirectories());
+        String testClassesDir = new File(
+                baseDir, project.getBuild().getTestOutputDirectory()).getAbsolutePath();
 
-        getLog().debug("Test classes dir: "
-                + new File(baseDir, "target/test-classes").getAbsolutePath());
+        Set<String> allTestClasses = new HashSet<>(
+                new TestListResolver(
+                        includes, excludes, getTest(), testClassesDir).scanDirectories());
+
+        getLog().debug("Test classes dir: " + testClassesDir);
         getLog().debug("Test classes found: " + String.join(",", allTestClasses));
 
         int exitCode;

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -150,6 +150,10 @@ public class SuperTestMavenPlugin extends AbstractMojo {
     }
 
     public String getTest() {
+        if (mvnTestOpts == null) {
+            return "";
+        }
+
         Matcher matcher = TEST_REGEX_PATTERN.matcher(mvnTestOpts);
         return matcher.find() ? matcher.group(1) : "";
     }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -81,14 +81,13 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         final String groupId = project.getGroupId();
 
         pool = Executors.newFixedThreadPool(1);
-        String testClassesDir = new File(
-                baseDir, project.getBuild().getTestOutputDirectory()).getAbsolutePath();
+        String testClassesDir = project.getBuild().getTestOutputDirectory();
 
         Set<String> allTestClasses = new HashSet<>(
                 new TestListResolver(
                         includes, excludes, getTest(), testClassesDir).scanDirectories());
 
-        getLog().debug("Test classes dir: " + testClassesDir);
+        getLog().info("Test classes dir: " + testClassesDir);
         getLog().debug("Test classes found: " + String.join(",", allTestClasses));
 
         int exitCode;

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
@@ -50,7 +50,7 @@ public class SurefireReportParser {
                 uniqueNames.add(name);
             }
         }
-        uniqueNames.forEach(result::addTestCase);
+        uniqueNames.forEach(result::addFailedTestCase);
         return result;
     }
 

--- a/src/main/java/com/clevertap/maven/plugins/supertest/TestListResolver.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/TestListResolver.java
@@ -1,0 +1,84 @@
+package com.clevertap.maven.plugins.supertest;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.surefire.util.DirectoryScanner;
+
+public class TestListResolver {
+    private static final String[] DEFAULT_INCLUDES = new String[] {
+            "**/Test*.java", "**/*Test.java", "**/*Tests.java", "**/*TestCase.java"};
+    private static final String[] DEFAULT_EXCLUDES = new String[] {"**/*$*"};
+
+    private final DirectoryScanner scanner;
+
+    public TestListResolver(
+            List<String> includes, List<String> excludes, String test, String testClassDir)
+            throws MojoFailureException {
+        scanner = new DirectoryScanner(
+                new File(testClassDir),
+                new org.apache.maven.surefire.testset.TestListResolver(
+                        getIncludeList(test, includes), getExcludeList(test, excludes)));
+    }
+
+    public List<String> scanDirectories() {
+        return scanner.scan().getClasses();
+    }
+
+    private List<String> getIncludeList(String test, List<String> includes)
+            throws MojoFailureException {
+        return getFilterList(test, includes, DEFAULT_INCLUDES, x -> x.split(","));
+    }
+
+    private List<String> getExcludeList(String test, List<String> excludes)
+            throws MojoFailureException {
+        return getFilterList(test, excludes, DEFAULT_EXCLUDES, x -> new String[] {});
+    }
+
+    private List<String> getFilterList(
+            String test,
+            List<String> filterData,
+            String[] defaultFilterData,
+            Function<String, String[]> parseTestFunc) throws MojoFailureException {
+        List<String> filterList = new ArrayList<>();
+
+        if (isSpecificTestSpecified(test)) {
+            Collections.addAll(filterList, parseTestFunc.apply(test));
+        } else {
+            if (filterData != null) {
+                filterList.addAll(filterData);
+                checkMethodFilterInIncludesExcludes(filterList);
+            }
+
+            if (filterList.isEmpty()) {
+                Collections.addAll(filterList, defaultFilterData);
+            }
+        }
+
+        return filterNulls(filterList);
+    }
+
+    private static boolean isSpecificTestSpecified(String test) {
+        return test != null && !test.isEmpty();
+    }
+
+    private static void checkMethodFilterInIncludesExcludes(Iterable<String> patterns)
+            throws MojoFailureException {
+        for (String pattern : patterns) {
+            if (pattern != null && pattern.contains( "#" )) {
+                throw new MojoFailureException(
+                        "Method filter prohibited in includes|excludes parameter: " + pattern);
+            }
+        }
+    }
+
+    private static List<String> filterNulls(List<String> toFilter) {
+        return toFilter.stream()
+                .filter(x -> x != null && !x.trim().isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
@@ -1,7 +1,13 @@
 package com.clevertap.maven.plugins.supertest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
@@ -13,8 +19,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertTrue;
 
 class SuperTestMavenPluginTest {
     @Test
@@ -36,11 +40,52 @@ class SuperTestMavenPluginTest {
         Set<String> allTestClasses = new HashSet<>();
         allTestClasses.add(FooTestResult.getClassName());
         allTestClasses.add(BarTestResult.getClassName());
+        allTestClasses.add("com.example.NotRun1");
+        allTestClasses.add("com.example.NotRun2");
 
         String rerunCommand = bv.createRerunCommand(allTestClasses, classnameToTestcaseList);
-        System.out.println(rerunCommand);
-        // added additional condition because hashset can give any order
-        assertTrue("mvn test -Dtest=com.example.FooTest,com.example.BarTest#barTest1*+barTest2*,".equals(rerunCommand)
-                || "mvn test -Dtest=com.example.FooTest,com.example.BarTest#barTest2*+barTest1*,".equals(rerunCommand));
+        assertTrue(rerunCommand.startsWith("mvn test -Dtest="));
+        assertEquals(
+                getRunCommandTestValue(
+                        "mvn test -Dtest=com.example.FooTest,"
+                                + "com.example.BarTest#barTest1*+barTest2*,"
+                                + "com.example.NotRun1,com.example.NotRun2"),
+                getRunCommandTestValue(rerunCommand));
+    }
+
+    /**
+     * Extracts test param from mvn test -Dtest=... and converts it to a set of test classes, where
+     * each test class is represented as a pair of name + set of test methods to be run.
+     */
+    private Set<Pair<String, Set<String>>> getRunCommandTestValue(String runCommand) {
+        // E.g. com.example.BarTest#barTest1*+barTest2* is converted to
+        // <com.example.BarTest, [barTest1*, barTest2*]>
+        String test = runCommand.substring("mvn test -Dtest=".length());
+        return Arrays.stream(test.split(",")).map(x -> {
+            if (x.contains("#")) {
+                int methodsStartIndex = x.indexOf('#');
+                return Pair.of(
+                        x.substring(0, methodsStartIndex),
+                        Arrays.stream(x.substring(methodsStartIndex + 1).split("\\+"))
+                                .collect(Collectors.toSet()));
+            } else {
+                return Pair.of(x, (Set<String>) new HashSet<String>());
+            }
+        }).collect(Collectors.toSet());
+    }
+
+    @Test
+    void testGetTestWhenProvided() {
+        SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
+        plugin.mvnTestOpts = "-PdontReuseForks -Dtest=**PowerMock** jacoco:report";
+        assertEquals("**PowerMock**", plugin.getTest());
+    }
+
+    @Test
+    void testGetTestWhenNotProvided() {
+        SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
+        assertEquals("", plugin.getTest());
+        plugin.mvnTestOpts = "";
+        assertEquals("", plugin.getTest());
     }
 }

--- a/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
@@ -1,5 +1,7 @@
 package com.clevertap.maven.plugins.supertest;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
@@ -16,7 +18,8 @@ import static org.junit.Assert.assertTrue;
 
 class SuperTestMavenPluginTest {
     @Test
-    void createRerunCommandTest() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+    void createRerunCommandTest()
+            throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
         SuperTestMavenPlugin bv = new SuperTestMavenPlugin();
         ClassLoader classLoader = getClass().getClassLoader();
         URL FooTest = classLoader.getResource("FooTest.xml");
@@ -25,10 +28,16 @@ class SuperTestMavenPluginTest {
         final RunResult BarTestResult = new SurefireReportParser(new File(BarTest.toURI())).parse();
 
         final Map<String, List<String>> classnameToTestcaseList = new HashMap<>();
-        classnameToTestcaseList.put(FooTestResult.getClassName(), FooTestResult.getTestCases());
-        classnameToTestcaseList.put(BarTestResult.getClassName(), BarTestResult.getTestCases());
+        classnameToTestcaseList.put(
+                FooTestResult.getClassName(), FooTestResult.getFailedTestCases());
+        classnameToTestcaseList.put(
+                BarTestResult.getClassName(), BarTestResult.getFailedTestCases());
 
-        String rerunCommand = bv.createRerunCommand(classnameToTestcaseList);
+        Set<String> allTestClasses = new HashSet<>();
+        allTestClasses.add(FooTestResult.getClassName());
+        allTestClasses.add(BarTestResult.getClassName());
+
+        String rerunCommand = bv.createRerunCommand(allTestClasses, classnameToTestcaseList);
         System.out.println(rerunCommand);
         // added additional condition because hashset can give any order
         assertTrue("mvn test -Dtest=com.example.FooTest,com.example.BarTest#barTest1*+barTest2*,".equals(rerunCommand)

--- a/src/test/java/com/clevertap/maven/plugins/supertest/TestListResolverTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/TestListResolverTest.java
@@ -1,0 +1,182 @@
+package com.clevertap.maven.plugins.supertest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class TestListResolverTest {
+    private static final String TEST_CLASS_DIR = "target/sample-test-classes";
+
+    @BeforeAll
+    public static void setUpBeforeClass() throws IOException {
+        createSampleTestClasses();
+    }
+
+    @Test
+    void testScanDirectoriesWithDefaultIncludes() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(null, null, null, TEST_CLASS_DIR);
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Arrays.asList(
+                "RootLevelClassTest",
+                "Test1",
+                "nested1.NestedClass1Test",
+                "nested1.AnotherNestedTest",
+                "nested1.SampleTests",
+                "nested1.nested2.NestedLevel2Test",
+                "nested1.nested2.NestedLevel2TestCase");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWithCustomPattern() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(
+                Arrays.asList("nested1/**/*Test", "nested1/**/*Pattern"),
+                null,
+                null,
+                TEST_CLASS_DIR);
+
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Arrays.asList(
+                "nested1.NestedClass1Test",
+                "nested1.AnotherNestedTest",
+                "nested1.NonMatchingPattern",
+                "nested1.nested2.NestedLevel2Test");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWithExcludes() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(
+                null,
+                Collections.singletonList("nested1/**/*Test"),
+                null,
+                TEST_CLASS_DIR);
+
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Arrays.asList(
+                "RootLevelClassTest",
+                "Test1",
+                "nested1.SampleTests",
+                "nested1.nested2.NestedLevel2TestCase");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWhenTestParamProvided() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(
+                null,
+                null,
+                "RootLevelClassTest,SampleTests,nested1.nested2.NestedLevel2TestCase",
+                TEST_CLASS_DIR);
+
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Arrays.asList(
+                "RootLevelClassTest",
+                "nested1.SampleTests",
+                "nested1.nested2.NestedLevel2TestCase");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWithRegexInclude() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(
+                Arrays.asList("%regex[.*Another.*]", "%regex[nested1.*Pattern.*.class]"),
+                null,
+                null,
+                TEST_CLASS_DIR);
+
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Arrays.asList(
+                "nested1.AnotherNestedTest",
+                "nested1.NonMatchingPattern");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWithMethodFilterInTest() throws MojoFailureException {
+        TestListResolver testListResolver = new TestListResolver(
+                null,
+                null,
+                "AnotherNestedTest#test()",
+                TEST_CLASS_DIR);
+        List<String> actualTestClasses = testListResolver.scanDirectories();
+        List<String> expectedTestClasses = Collections.singletonList("nested1.AnotherNestedTest");
+
+        assertEquals(new HashSet<>(expectedTestClasses), new HashSet<>(actualTestClasses));
+    }
+
+    @Test
+    void testScanDirectoriesWithMethodFilterInIncludes() {
+        assertThrows(
+                MojoFailureException.class,
+                () -> new TestListResolver(
+                        Collections.singletonList("AnotherNestedTest#test()"),
+                        null,
+                        null,
+                        TEST_CLASS_DIR),
+                "Method filter prohibited in includes|excludes parameter:AnotherNestedTest#test()");
+    }
+
+    @Test
+    void testScanDirectoriesWithMethodFilterInExcludes() {
+        assertThrows(
+                MojoFailureException.class,
+                () -> new TestListResolver(
+                        null,
+                        Collections.singletonList("AnotherNestedTest#test()"),
+                        null,
+                        TEST_CLASS_DIR),
+                "Method filter prohibited in includes|excludes parameter:AnotherNestedTest#test()");
+    }
+
+    // creates a few classes to be used for testing the resolver
+    private static void createSampleTestClasses() throws IOException {
+        // clean-up any old copies of the sample test dir
+        deleteDir(TEST_CLASS_DIR);
+
+        Files.createDirectories(Paths.get(TEST_CLASS_DIR));
+        Files.createDirectories(Paths.get(TEST_CLASS_DIR, "nested1"));
+        Files.createDirectories(Paths.get(TEST_CLASS_DIR, "nested1", "nested2"));
+
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "RootLevelClassTest.class"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "NonClassExtensionTest.java"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "Test1.class"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "nested1", "NestedClass1Test.class"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "nested1", "AnotherNestedTest.class"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "nested1", "NonMatchingPattern.class"));
+        Files.createFile(Paths.get(TEST_CLASS_DIR, "nested1", "SampleTests.class"));
+        Files.createFile(Paths.get(
+                TEST_CLASS_DIR, "nested1", "nested2", "NestedLevel2Test.class"));
+        Files.createFile(Paths.get(
+                TEST_CLASS_DIR, "nested1", "nested2", "NestedLevel2TestCase.class"));
+    }
+
+    private static void deleteDir(String dir) throws IOException {
+        if (!new File(dir).exists()) {
+            return;
+        }
+
+        try (Stream<Path> paths = Files.walk(Paths.get(dir))) {
+            paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        }
+    }
+}

--- a/src/test/java/com/clevertap/maven/plugins/supertest/ValidIdentifierTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/ValidIdentifierTest.java
@@ -1,5 +1,7 @@
 package com.clevertap.maven.plugins.supertest;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
@@ -16,16 +18,22 @@ import static org.junit.Assert.assertEquals;
 
 class ValidIdentifierTest {
     @Test
-    void testValidIdentifier() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+    void testValidIdentifier()
+            throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
         SuperTestMavenPlugin bv = new SuperTestMavenPlugin();
         ClassLoader classLoader = getClass().getClassLoader();
         URL validIdentifierTest = classLoader.getResource("ValidIdentifierTest.xml");
-        final RunResult ValidIdentifierTestResult = new SurefireReportParser(new File(validIdentifierTest.toURI())).parse();
+        final RunResult validIdentifierTestResult =
+                new SurefireReportParser(new File(validIdentifierTest.toURI())).parse();
+        Set<String> allTestClasses = new HashSet<>();
+        allTestClasses.add("com.validIdentifierTest");
 
         final Map<String, List<String>> classnameToTestcaseList = new HashMap<>();
-        classnameToTestcaseList.put(ValidIdentifierTestResult.getClassName(), ValidIdentifierTestResult.getTestCases());
+        classnameToTestcaseList.put(
+                validIdentifierTestResult.getClassName(),
+                validIdentifierTestResult.getFailedTestCases());
 
-        String rerunCommand = bv.createRerunCommand(classnameToTestcaseList);
+        String rerunCommand = bv.createRerunCommand(allTestClasses, classnameToTestcaseList);
         System.out.println(rerunCommand);
         assertEquals("mvn test -Dtest=com.validIdentifierTest#fooTest*,", rerunCommand);
     }


### PR DESCRIPTION
In version 1.11, there is a regression which makes supertest mark a build as successful if `mvn test ...` exited prematurely (someone called `System.exit(...)` from the code for example) or was forcibly killed by supertest, because it took too long without any progress. This is caused by the fact that supertest relies on surefire reports, but they are generated only if a test is complete (either pass or fail). If a test is not complete, there is nothing in the surefire report and this was not considered as a condition for rerun. With the current fix, supertest now supports `includes` and `excludes` properties exactly as they are supported in maven surefire plugin and detects all tests to be executed by maven (default are the same as the ones for maven surefire plugin). So now if there is a premature exit, supertest does not rely on surefire report only but it checks if any of the tests to be executed has not passed yet and marks it for re-execution. 