### PR TITLE
exiting the process if 0 tests are run in retry run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.13</version>
+    <version>1.14</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -114,6 +114,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         for (int retryRunNumber = 1; retryRunNumber <= retryRunCount; retryRunNumber++) {
             final File[] xmlFileList = getXmlFileList(baseDir);
             final Map<String, List<String>> classnameToTestcaseList = new HashMap<>();
+            int testsToBeRetried = 0;
             for (File file : xmlFileList) {
                 final SurefireReportParser parser = new SurefireReportParser(file);
                 final RunResult runResult;
@@ -125,6 +126,11 @@ public class SuperTestMavenPlugin extends AbstractMojo {
                 }
                 classnameToTestcaseList.put(
                         runResult.getClassName(), runResult.getFailedTestCases());
+                testsToBeRetried += runResult.getFailedTestCases().size();
+            }
+
+            if (testsToBeRetried == 0) {
+                System.exit(1);
             }
 
             final String runCommand = createRerunCommand(allTestClasses, classnameToTestcaseList);


### PR DESCRIPTION
If no unit tests were found in the first run, SuperTest would exit with a status code 0, giving a false success.
This has been resolved now by checking the number of unit tests that are to be run in the retry run.