### PR TITLE
Fix nested test class failure detection and version bump to 1.15.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.clevertap</groupId>
     <artifactId>supertest-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.14</version>
+    <version>1.15</version>
     <description>A wrapper for Maven's Surefire Plugin, with advanced re-run capabilities.
     </description>
     <name>supertest-maven-plugin</name>

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -348,7 +348,8 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         // TODO: 04/02/2022 replace with Java 8 streams
         for (String className : classnameToTestcaseList.keySet()) {
             // For nested/inner test classes (e.g., com.example.OuterTest$InnerTest),
-            // resolve to the outermost class name since that's what surefire's -Dtest uses
+            // resolve to the outermost class name for tracking in allTestClasses/incompleteTests
+            // (since TestListResolver excludes nested classes from allTestClasses)
             String outerClassName = getOuterClassName(className);
 
             // if a test class is in the surefire report, it means that all its tests were executed
@@ -356,7 +357,9 @@ public class SuperTestMavenPlugin extends AbstractMojo {
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
 
             if (!failedTestCaseList.isEmpty()) {
-                appendFailedTestCases(outerClassName, failedTestCaseList, retryRun);
+                // Use the original class name (including $NestedClass) in the -Dtest parameter,
+                // since surefire needs the full nested class name to locate the test methods
+                appendFailedTestCases(className, failedTestCaseList, retryRun);
                 outerClassesWithFailures.add(outerClassName);
             }
         }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -341,17 +341,33 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         retryRun.append(" -Dtest=");
         int emptyRetryRunLen = retryRun.length();
 
+        // Track outer classes that have at least one nested class with failures,
+        // so we don't prematurely remove them from allTestClasses
+        Set<String> outerClassesWithFailures = new HashSet<>();
+
         // TODO: 04/02/2022 replace with Java 8 streams
         for (String className : classnameToTestcaseList.keySet()) {
+            // For nested/inner test classes (e.g., com.example.OuterTest$InnerTest),
+            // resolve to the outermost class name since that's what surefire's -Dtest uses
+            String outerClassName = getOuterClassName(className);
+
             // if a test class is in the surefire report, it means that all its tests were executed
-            incompleteTests.remove(className);
+            incompleteTests.remove(outerClassName);
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
 
             if (!failedTestCaseList.isEmpty()) {
-                appendFailedTestCases(className, failedTestCaseList, retryRun);
-            } else {
-                // passing tests will not be re-run anymore
-                allTestClasses.remove(className);
+                appendFailedTestCases(outerClassName, failedTestCaseList, retryRun);
+                outerClassesWithFailures.add(outerClassName);
+            }
+        }
+
+        // Remove passing test classes from allTestClasses, but only if none of their
+        // nested classes had failures
+        for (String className : classnameToTestcaseList.keySet()) {
+            String outerClassName = getOuterClassName(className);
+            List<String> failedTestCaseList = classnameToTestcaseList.get(className);
+            if (failedTestCaseList.isEmpty() && !outerClassesWithFailures.contains(outerClassName)) {
+                allTestClasses.remove(outerClassName);
             }
         }
 
@@ -364,6 +380,15 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         retryRun.append(String.join(",", incompleteTests));
 
         return retryRun.length() != emptyRetryRunLen ? retryRun.toString() : null;
+    }
+
+    /**
+     * Returns the outermost class name for nested/inner test classes.
+     * E.g., "com.example.OuterTest$InnerTest$DeepNested" -> "com.example.OuterTest"
+     */
+    String getOuterClassName(String className) {
+        int dollarIndex = className.indexOf('$');
+        return dollarIndex > 0 ? className.substring(0, dollarIndex) : className;
     }
 
     private void appendFailedTestCases(

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -341,9 +341,13 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         retryRun.append(" -Dtest=");
         int emptyRetryRunLen = retryRun.length();
 
+        // Track which outer classes have failures to avoid removing them
+        // from allTestClasses when a passing nested class report is processed
         Set<String> outerClassesWithFailures = new HashSet<>();
 
         for (String className : classnameToTestcaseList.keySet()) {
+            // Resolve nested class names (e.g. OuterTest$Inner) to outer class,
+            // since TestListResolver excludes nested classes from allTestClasses
             String outerClassName = getOuterClassName(className);
             incompleteTests.remove(outerClassName);
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
@@ -354,6 +358,7 @@ public class SuperTestMavenPlugin extends AbstractMojo {
             }
         }
 
+        // Only remove passing classes if no nested class of the same outer class had failures
         for (String className : classnameToTestcaseList.keySet()) {
             String outerClassName = getOuterClassName(className);
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPlugin.java
@@ -341,31 +341,19 @@ public class SuperTestMavenPlugin extends AbstractMojo {
         retryRun.append(" -Dtest=");
         int emptyRetryRunLen = retryRun.length();
 
-        // Track outer classes that have at least one nested class with failures,
-        // so we don't prematurely remove them from allTestClasses
         Set<String> outerClassesWithFailures = new HashSet<>();
 
-        // TODO: 04/02/2022 replace with Java 8 streams
         for (String className : classnameToTestcaseList.keySet()) {
-            // For nested/inner test classes (e.g., com.example.OuterTest$InnerTest),
-            // resolve to the outermost class name for tracking in allTestClasses/incompleteTests
-            // (since TestListResolver excludes nested classes from allTestClasses)
             String outerClassName = getOuterClassName(className);
-
-            // if a test class is in the surefire report, it means that all its tests were executed
             incompleteTests.remove(outerClassName);
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);
 
             if (!failedTestCaseList.isEmpty()) {
-                // Use the original class name (including $NestedClass) in the -Dtest parameter,
-                // since surefire needs the full nested class name to locate the test methods
                 appendFailedTestCases(className, failedTestCaseList, retryRun);
                 outerClassesWithFailures.add(outerClassName);
             }
         }
 
-        // Remove passing test classes from allTestClasses, but only if none of their
-        // nested classes had failures
         for (String className : classnameToTestcaseList.keySet()) {
             String outerClassName = getOuterClassName(className);
             List<String> failedTestCaseList = classnameToTestcaseList.get(className);

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
@@ -37,19 +37,38 @@ public class SurefireReportParser {
         doc.getDocumentElement().normalize();
         final Node testsuite = doc.getElementsByTagName("testsuite").item(0);
 
-        final RunResult result = new RunResult(((Element) testsuite).getAttribute("name"));
+        final String suiteClassName = ((Element) testsuite).getAttribute("name");
+        final RunResult result = new RunResult(suiteClassName);
         final NodeList testCaseList = doc.getElementsByTagName("testcase");
+
+        boolean hasNestedClassFailure = false;
 
         for (int i = 0; i < testCaseList.getLength(); i++) {
             Node testCase = testCaseList.item(i);
             Node n = testCase.getChildNodes()
                     .item(1); // TODO: 04/02/2022 will fail if retry count is 0
-            if (testCase.hasChildNodes() && failureTagsList.contains(n.getNodeName())) {
+            if (testCase.hasChildNodes() && n != null && failureTagsList.contains(n.getNodeName())) {
                 Element testCaseElement = (Element) testCase;
-                String name = getLegalIdentifierName(testCaseElement.getAttribute("name"));
-                uniqueNames.add(name);
+                String testClassname = testCaseElement.getAttribute("classname");
+
+                // If the testcase classname differs from the testsuite name, the test
+                // belongs to a nested class. Surefire's -Dtest filter cannot target methods
+                // inside nested classes, so we must rerun the entire outer class.
+                if (!testClassname.isEmpty() && !testClassname.equals(suiteClassName)) {
+                    hasNestedClassFailure = true;
+                } else {
+                    String name = getLegalIdentifierName(testCaseElement.getAttribute("name"));
+                    uniqueNames.add(name);
+                }
             }
         }
+
+        if (hasNestedClassFailure) {
+            // Empty string signals to rerun the entire class without method filtering
+            uniqueNames.clear();
+            uniqueNames.add("");
+        }
+
         uniqueNames.forEach(result::addFailedTestCase);
         return result;
     }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
@@ -45,15 +45,11 @@ public class SurefireReportParser {
 
         for (int i = 0; i < testCaseList.getLength(); i++) {
             Node testCase = testCaseList.item(i);
-            Node n = testCase.getChildNodes()
-                    .item(1); // TODO: 04/02/2022 will fail if retry count is 0
+            Node n = testCase.getChildNodes().item(1);
             if (testCase.hasChildNodes() && n != null && failureTagsList.contains(n.getNodeName())) {
                 Element testCaseElement = (Element) testCase;
                 String testClassname = testCaseElement.getAttribute("classname");
 
-                // If the testcase classname differs from the testsuite name, the test
-                // belongs to a nested class. Surefire's -Dtest filter cannot target methods
-                // inside nested classes, so we must rerun the entire outer class.
                 if (!testClassname.isEmpty() && !testClassname.equals(suiteClassName)) {
                     hasNestedClassFailure = true;
                 } else {
@@ -64,7 +60,6 @@ public class SurefireReportParser {
         }
 
         if (hasNestedClassFailure) {
-            // Empty string signals to rerun the entire class without method filtering
             uniqueNames.clear();
             uniqueNames.add("");
         }

--- a/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
+++ b/src/main/java/com/clevertap/maven/plugins/supertest/SurefireReportParser.java
@@ -50,6 +50,9 @@ public class SurefireReportParser {
                 Element testCaseElement = (Element) testCase;
                 String testClassname = testCaseElement.getAttribute("classname");
 
+                // Surefire 3.x reports @Nested class tests under the outer class XML
+                // with the @DisplayName as classname. Since -Dtest cannot target methods
+                // inside nested classes, we rerun the entire outer class.
                 if (!testClassname.isEmpty() && !testClassname.equals(suiteClassName)) {
                     hasNestedClassFailure = true;
                 } else {
@@ -59,6 +62,8 @@ public class SurefireReportParser {
             }
         }
 
+        // Empty string signals createRerunCommand to rerun the entire class
+        // without method filtering
         if (hasNestedClassFailure) {
             uniqueNames.clear();
             uniqueNames.add("");

--- a/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
@@ -106,6 +106,57 @@ class SuperTestMavenPluginTest {
     }
 
     @Test
+    void createRerunCommandWithNestedTestClassFailure()
+            throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+        SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        // Nested inner class has a failure
+        URL nestedInnerTest = classLoader.getResource("NestedInnerTest.xml");
+        // Outer class has all passing tests
+        URL outerTest = classLoader.getResource("OuterTest.xml");
+
+        final RunResult nestedResult =
+                new SurefireReportParser(new File(nestedInnerTest.toURI())).parse();
+        final RunResult outerResult =
+                new SurefireReportParser(new File(outerTest.toURI())).parse();
+
+        // The nested class report has className "com.example.OuterTest$InnerTest"
+        assertEquals("com.example.OuterTest$InnerTest", nestedResult.getClassName());
+        assertEquals(1, nestedResult.getFailedTestCases().size());
+
+        final Map<String, List<String>> classNameToTestCaseList = new HashMap<>();
+        classNameToTestCaseList.put(
+                nestedResult.getClassName(), nestedResult.getFailedTestCases());
+        classNameToTestCaseList.put(
+                outerResult.getClassName(), outerResult.getFailedTestCases());
+
+        // allTestClasses only has the outer class (nested classes are excluded by TestListResolver)
+        Set<String> allTestClasses = new HashSet<>();
+        allTestClasses.add("com.example.OuterTest");
+
+        String rerunCommand = plugin.createRerunCommand(allTestClasses, classNameToTestCaseList);
+
+        // The retry should use the outer class name, not the nested class name
+        assertTrue(rerunCommand.startsWith("mvn test -Dtest="));
+        assertEquals(
+                getRunCommandTestValue(
+                        "mvn test -Dtest=com.example.OuterTest#innerTest1*"),
+                getRunCommandTestValue(rerunCommand));
+    }
+
+    @Test
+    void testGetOuterClassName() {
+        SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
+        assertEquals("com.example.OuterTest",
+                plugin.getOuterClassName("com.example.OuterTest$InnerTest"));
+        assertEquals("com.example.OuterTest",
+                plugin.getOuterClassName("com.example.OuterTest$InnerTest$DeepNested"));
+        assertEquals("com.example.SimpleTest",
+                plugin.getOuterClassName("com.example.SimpleTest"));
+    }
+
+    @Test
     void testGetTestWhenProvided() {
         SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
         plugin.mvnTestOpts = "-PdontReuseForks -Dtest=**PowerMock** jacoco:report";

--- a/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
@@ -137,11 +137,11 @@ class SuperTestMavenPluginTest {
 
         String rerunCommand = plugin.createRerunCommand(allTestClasses, classNameToTestCaseList);
 
-        // The retry should use the outer class name, not the nested class name
+        // The retry should use the full nested class name (with $) so surefire can find the method
         assertTrue(rerunCommand.startsWith("mvn test -Dtest="));
         assertEquals(
                 getRunCommandTestValue(
-                        "mvn test -Dtest=com.example.OuterTest#innerTest1*"),
+                        "mvn test -Dtest=com.example.OuterTest$InnerTest#innerTest1*"),
                 getRunCommandTestValue(rerunCommand));
     }
 

--- a/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
+++ b/src/test/java/com/clevertap/maven/plugins/supertest/SuperTestMavenPluginTest.java
@@ -111,37 +111,32 @@ class SuperTestMavenPluginTest {
         SuperTestMavenPlugin plugin = new SuperTestMavenPlugin();
         ClassLoader classLoader = getClass().getClassLoader();
 
-        // Nested inner class has a failure
+        // Surefire 3.x puts nested class tests in the outer class XML,
+        // with a different classname attribute (display name instead of FQCN)
         URL nestedInnerTest = classLoader.getResource("NestedInnerTest.xml");
-        // Outer class has all passing tests
-        URL outerTest = classLoader.getResource("OuterTest.xml");
 
-        final RunResult nestedResult =
+        final RunResult result =
                 new SurefireReportParser(new File(nestedInnerTest.toURI())).parse();
-        final RunResult outerResult =
-                new SurefireReportParser(new File(outerTest.toURI())).parse();
 
-        // The nested class report has className "com.example.OuterTest$InnerTest"
-        assertEquals("com.example.OuterTest$InnerTest", nestedResult.getClassName());
-        assertEquals(1, nestedResult.getFailedTestCases().size());
+        // The testsuite name is the outer class
+        assertEquals("com.example.OuterTest", result.getClassName());
+        // Nested class failure should trigger a full class rerun (empty string marker)
+        assertEquals(1, result.getFailedTestCases().size());
+        assertTrue(result.getFailedTestCases().contains(""));
 
         final Map<String, List<String>> classNameToTestCaseList = new HashMap<>();
-        classNameToTestCaseList.put(
-                nestedResult.getClassName(), nestedResult.getFailedTestCases());
-        classNameToTestCaseList.put(
-                outerResult.getClassName(), outerResult.getFailedTestCases());
+        classNameToTestCaseList.put(result.getClassName(), result.getFailedTestCases());
 
-        // allTestClasses only has the outer class (nested classes are excluded by TestListResolver)
         Set<String> allTestClasses = new HashSet<>();
         allTestClasses.add("com.example.OuterTest");
 
         String rerunCommand = plugin.createRerunCommand(allTestClasses, classNameToTestCaseList);
 
-        // The retry should use the full nested class name (with $) so surefire can find the method
+        // When a nested class has failures, the entire outer class should be rerun
+        // without method filtering (no #method suffix)
         assertTrue(rerunCommand.startsWith("mvn test -Dtest="));
         assertEquals(
-                getRunCommandTestValue(
-                        "mvn test -Dtest=com.example.OuterTest$InnerTest#innerTest1*"),
+                getRunCommandTestValue("mvn test -Dtest=com.example.OuterTest"),
                 getRunCommandTestValue(rerunCommand));
     }
 

--- a/src/test/resources/NestedInnerTest.xml
+++ b/src/test/resources/NestedInnerTest.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd"
-           version="3.0" name="com.example.OuterTest$InnerTest" time="0.353" tests="1" errors="0" skipped="0" failures="1">
-    <testcase name="innerTest1" classname="com.example.OuterTest$InnerTest" time="0.045">
+           version="3.0" name="com.example.OuterTest" time="0.353" tests="3" errors="0" skipped="0" failures="1">
+    <testcase name="outerTest1" classname="com.example.OuterTest" time="0.023">
+    </testcase>
+    <testcase name="innerTest1" classname="Inner Test Suite" time="0.045">
         <failure message="expected: &lt;1&gt; but was: &lt;2&gt;" type="org.opentest4j.AssertionFailedError">
             at com.example.OuterTest$InnerTest.innerTest1
         </failure>
+    </testcase>
+    <testcase name="innerTest2" classname="Inner Test Suite" time="0.005">
     </testcase>
 </testsuite>

--- a/src/test/resources/NestedInnerTest.xml
+++ b/src/test/resources/NestedInnerTest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd"
+           version="3.0" name="com.example.OuterTest$InnerTest" time="0.353" tests="1" errors="0" skipped="0" failures="1">
+    <testcase name="innerTest1" classname="com.example.OuterTest$InnerTest" time="0.045">
+        <failure message="expected: &lt;1&gt; but was: &lt;2&gt;" type="org.opentest4j.AssertionFailedError">
+            at com.example.OuterTest$InnerTest.innerTest1
+        </failure>
+    </testcase>
+</testsuite>

--- a/src/test/resources/OuterTest.xml
+++ b/src/test/resources/OuterTest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd"
+           version="3.0" name="com.example.OuterTest" time="0.123" tests="1" errors="0" skipped="0" failures="0">
+</testsuite>


### PR DESCRIPTION
## Summary

Fixes a bug where test failures in JUnit 5 `@Nested` inner classes were not retried by the supertest plugin.

**Root cause:** Surefire 3.x reports nested class test cases inside the outer class's XML report, but uses the `@DisplayName` (e.g., `"AddNumbers Method Tests"`) as the `classname` attribute instead of the FQCN. The plugin was building a retry command like `-Dtest=OuterClass#nestedMethod*`, but surefire's `-Dtest` filter cannot locate methods that only exist inside nested classes when filtering by the outer class name — resulting in `Tests run: 0` on retry.

**Fix:**
- `SurefireReportParser` now detects nested class failures by comparing `testcase/@classname` against `testsuite/@name`
- When a nested class test fails, the entire outer class is rerun without method filtering (`-Dtest=OuterClass` instead of `-Dtest=OuterClass#method*`), since surefire has no way to target individual methods inside nested classes
- Adds a null check for `testcase` child nodes to prevent NPE on test cases with no failure/error elements
- `createRerunCommand` uses `getOuterClassName()` to correctly track nested class reports (from other surefire versions that generate separate `$`-prefixed XMLs) against `allTestClasses`, which excludes inner classes via `**/*$*`

**Version bumped to 1.15.**

## Test plan

- [x] Added `NestedInnerTest.xml` test fixture matching real surefire 3.5.4 output format (nested class tests with display name as classname)
- [x] Added `createRerunCommandWithNestedTestClassFailure` test verifying entire outer class is rerun
- [x] Added `testGetOuterClassName` unit test
- [x] Existing tests continue to pass (17/17)
